### PR TITLE
add extra FFMPEG global options support to both presets.xml and GUI

### DIFF
--- a/src/converter/conversionparameters.cpp
+++ b/src/converter/conversionparameters.cpp
@@ -132,7 +132,7 @@ void ConversionParameters::copyConfigurationFrom(const ConversionParameters &src
 }
 
 ConversionParameters
-ConversionParameters::fromFFmpegParameters(const QString &params_str)
+ConversionParameters::fromFFmpegParameters(const QString &globals_str, const QString &params_str)
 {
     ConversionParameters result;
     QStringList args = params_str.split(" ", QString::SkipEmptyParts);
@@ -148,13 +148,14 @@ ConversionParameters::fromFFmpegParameters(const QString &params_str)
         }
     }
 
+    result.ffmpeg_globals = globals_str;
     result.ffmpeg_options = args.join(" "); // unrecognized arguments
 
     return result;
 }
 
 ConversionParameters
-ConversionParameters::fromFFmpegParameters(const char *params_str)
+ConversionParameters::fromFFmpegParameters(const char *globals_str, const char *params_str)
 {
-    return fromFFmpegParameters(QString(params_str));
+    return fromFFmpegParameters(QString(globals_str), QString(params_str));
 }

--- a/src/converter/conversionparameters.h
+++ b/src/converter/conversionparameters.h
@@ -51,6 +51,7 @@ public:
     /* FFmpeg Specific Options */
     /*! Additional options passed to the ffmpeg transcoder.
         These options will be overriden by other specific options. */
+    QString ffmpeg_globals;
     QString ffmpeg_options;
 
     /* MEncoder Specific Options */
@@ -77,8 +78,8 @@ public:
 
     /*! Generate a ConversionParameters from ffmpeg command line options.
         This function ignores input and output file options. */
-    static ConversionParameters fromFFmpegParameters(const QString& params_str);
-    static ConversionParameters fromFFmpegParameters(const char *params_str);
+    static ConversionParameters fromFFmpegParameters(const QString& globals_str, const QString& params_str);
+    static ConversionParameters fromFFmpegParameters(const char *globals_str, const char *params_str);
 
     ConversionParameters()
         : threads(0),

--- a/src/converter/ffmpeginterface.cpp
+++ b/src/converter/ffmpeginterface.cpp
@@ -361,6 +361,8 @@ QStringList FFmpegInterface::Private::getOptionList(const ConversionParameters &
     // overwrite if file exists
     list.append("-y");
 
+    list.append(o.ffmpeg_globals);
+
     if (!bNeedsAudioFilter) {
         /* in this configuration, input is read from file
            arguments: -i <infile>

--- a/src/converter/presets.cpp
+++ b/src/converter/presets.cpp
@@ -128,6 +128,12 @@ bool Presets::Private::readElementData(QXmlStreamReader &xml, Preset& target)
 
     if (property_name == "label") {
         target.label = property_value;
+    } else if (property_name == "globals") {
+        Version ffmpegVersion(FFmpegInterface::getFFmpegVersionInfo());
+        if (versionrange_str.isEmpty()
+                || VersionRange(versionrange_str).containsVersion(ffmpegVersion)) {
+            target.globals = property_value;
+        }
     } else if (property_name == "params") {
         Version ffmpegVersion(FFmpegInterface::getFFmpegVersionInfo());
         if (versionrange_str.isEmpty()

--- a/src/converter/presets.h
+++ b/src/converter/presets.h
@@ -28,6 +28,7 @@ public:
     QString extension;
     QString label;
     QString category;
+    QString globals;
     QString parameters;
 
     /*! Sorting requires less-than operator.

--- a/src/ui/addtaskwizard.cpp
+++ b/src/ui/addtaskwizard.cpp
@@ -256,7 +256,7 @@ void AddTaskWizard::slotPresetSelected(int index)
     if (!m_presets->findPresetById(id, preset)) {
         return; // assert false
     }
-    *m_current_param = ConversionParameters::fromFFmpegParameters(preset.parameters);
+    *m_current_param = ConversionParameters::fromFFmpegParameters(preset.globals, preset.parameters);
 }
 
 // This function is executed when the users presses "Finish"

--- a/src/ui/conversionparameterdialog.cpp
+++ b/src/ui/conversionparameterdialog.cpp
@@ -130,6 +130,7 @@ AbstractPreviewer *ConversionParameterDialog::create_previewer()
 void ConversionParameterDialog::read_fields(const ConversionParameters& param)
 {
     // Additional Options
+    ui->txtFFmpegGlobals->setPlainText(param.ffmpeg_globals);
     ui->txtFFmpegOptions->setPlainText(param.ffmpeg_options);
 
     // Audio Options
@@ -213,7 +214,8 @@ void ConversionParameterDialog::read_fields(const ConversionParameters& param)
 void ConversionParameterDialog::write_fields(ConversionParameters& param)
 {
     // Additional Options
-    param = param.fromFFmpegParameters(ui->txtFFmpegOptions->toPlainText());
+    param = param.fromFFmpegParameters(ui->txtFFmpegGlobals->toPlainText(),
+                                       ui->txtFFmpegOptions->toPlainText());
 
     // Audio Options
     param.disable_audio = ui->chkDisableAudio->isChecked();

--- a/src/ui/conversionparameterdialog.ui
+++ b/src/ui/conversionparameterdialog.ui
@@ -520,6 +520,20 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
+             <layout class="QVBoxLayout" name="verticalLayout_10">
+              <item>
+               <widget class="QLabel" name="lblFFmpegGlobals">
+                <property name="text">
+                 <string>Additional FFmpeg Global Options</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPlainTextEdit" name="txtFFmpegGlobals"/>
+              </item>
+             </layout>
+            </item>
+            <item>
              <layout class="QVBoxLayout" name="verticalLayout_4">
               <item>
                <widget class="QLabel" name="lblFFmpegOptions">


### PR DESCRIPTION
The '-strict strict' or '-cpuflags -sse+mmx' parameters can be used
globally. Add support for this.