### PR TITLE
Correct english translation

### DIFF
--- a/src/translations/qwinff_ar.ts
+++ b/src/translations/qwinff_ar.ts
@@ -802,7 +802,7 @@
         <translation>أظهر ر&amp;سالة الخطأ</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>التم&amp;س التحديثات</translation>
     </message>
     <message>

--- a/src/translations/qwinff_cs_CZ.ts
+++ b/src/translations/qwinff_cs_CZ.ts
@@ -802,7 +802,7 @@
         <translation>Zobrazit Chybovou &amp;Hlášku</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/qwinff_de.ts
+++ b/src/translations/qwinff_de.ts
@@ -802,7 +802,7 @@
         <translation>Zeige &amp;Fehlermeldung</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Suche nach &amp;Updates</translation>
     </message>
     <message>

--- a/src/translations/qwinff_es_ES.ts
+++ b/src/translations/qwinff_es_ES.ts
@@ -800,7 +800,7 @@
         <translation>&amp;Mostrar mensage de error</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Buscar &amp;actualizaciones</translation>
     </message>
     <message>

--- a/src/translations/qwinff_es_GT.ts
+++ b/src/translations/qwinff_es_GT.ts
@@ -812,7 +812,7 @@
         <translation>&amp;Mostrar mensage de error</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/qwinff_fr.ts
+++ b/src/translations/qwinff_fr.ts
@@ -802,7 +802,7 @@
         <translation>Montrer les &amp;messages d&apos;erreurs</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>&amp;Vérifier les mises à jours</translation>
     </message>
     <message>

--- a/src/translations/qwinff_hu_HU.ts
+++ b/src/translations/qwinff_hu_HU.ts
@@ -800,7 +800,7 @@
         <translation>Hibaüzenetek megjelenítése</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Frissítések ellenőrzése</translation>
     </message>
     <message>

--- a/src/translations/qwinff_it_IT.ts
+++ b/src/translations/qwinff_it_IT.ts
@@ -802,7 +802,7 @@
         <translation>Mostra &amp;messaggio di errore</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Controlla  gli &amp;aggiornamenti</translation>
     </message>
     <message>

--- a/src/translations/qwinff_ja_JP.ts
+++ b/src/translations/qwinff_ja_JP.ts
@@ -800,7 +800,7 @@
         <translation>エラーメッセージを表示(&amp;M)</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>更新のチェック(&amp;U)</translation>
     </message>
     <message>

--- a/src/translations/qwinff_pl_PL.ts
+++ b/src/translations/qwinff_pl_PL.ts
@@ -802,7 +802,7 @@
         <translation>Wyświetl informację o błędzie </translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Sprawdź &amp;aktualizacje</translation>
     </message>
     <message>

--- a/src/translations/qwinff_pt_BR.ts
+++ b/src/translations/qwinff_pt_BR.ts
@@ -802,7 +802,7 @@
         <translation>Mostrar mensagem de erro</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Verificar atualizações</translation>
     </message>
     <message>

--- a/src/translations/qwinff_ro_RO.ts
+++ b/src/translations/qwinff_ro_RO.ts
@@ -802,7 +802,7 @@
         <translation>Afişează &amp;Mesajul de Eroare</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Verifică pentru act&amp;ualizări</translation>
     </message>
     <message>

--- a/src/translations/qwinff_ru.ts
+++ b/src/translations/qwinff_ru.ts
@@ -801,7 +801,7 @@
         <translation>Показать &amp;сообщение об ошибке</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>Проверить &amp;обновления</translation>
     </message>
     <message>

--- a/src/translations/qwinff_tr_TR.ts
+++ b/src/translations/qwinff_tr_TR.ts
@@ -801,7 +801,7 @@
         <translation>Hata Göster &amp;İleti</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/qwinff_zh_CN.ts
+++ b/src/translations/qwinff_zh_CN.ts
@@ -800,7 +800,7 @@
         <translation>显示错误信息(&amp;M)</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>检查更新(&amp;U)</translation>
     </message>
     <message>

--- a/src/translations/qwinff_zh_TW.ts
+++ b/src/translations/qwinff_zh_TW.ts
@@ -800,7 +800,7 @@
         <translation>顯示錯誤訊息(&amp;M)</translation>
     </message>
     <message>
-        <source>Check For &amp;Updates</source>
+        <source>Check for &amp;Updates</source>
         <translation>檢查更新(&amp;U)</translation>
     </message>
     <message>

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -375,7 +375,7 @@
      <normaloff>:/actions/icons/check_update.png</normaloff>:/actions/icons/check_update.png</iconset>
    </property>
    <property name="text">
-    <string>Check For &amp;Updates</string>
+    <string>Check for &amp;Updates</string>
    </property>
   </action>
   <action name="actionCut">


### PR DESCRIPTION
'for' shouldn't be capitalized in titles.

Also see [here](http://grammar.yourdictionary.com/capitalization/rules-for-capitalization-in-titles.html) rules for capitatlization in titles.