### PR TITLE
Link qmpwidget statically

### DIFF
--- a/src/qmpwidget/CMakeLists.txt
+++ b/src/qmpwidget/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(qmpwidget qmpwidget.cpp)
+add_library(qmpwidget STATIC qmpwidget.cpp)
 target_link_libraries(qmpwidget Qt5::Widgets)


### PR DESCRIPTION
Otherwise qwinff binary depends from libqmpwidget.so whcih is not and should not be installed.